### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Change webview engine. Application needs to be restarted for change to take effe
 
 ```javascript
 var ws = window.cordova.plugins.WebViewSelector;
-ws.setEngine(ws.WebViewType.SYSTEM, function (error) {
+ws.setEngine('SYSTEM', function (error) {
 	if (error) {
 		return console.error(error);
 	}


### PR DESCRIPTION
The setEngine code looks up values from ws.WebViewType by key, so we should use the key, not value, else this code will give an error:
if (WebViewSelector.WebViewType[engineId] === undefined) {
  return cb('unknown webview type: ' + engineId);
}